### PR TITLE
Fix install failing at "Installing prerequisites..."

### DIFF
--- a/setup/node-red_setup.sh
+++ b/setup/node-red_setup.sh
@@ -29,6 +29,7 @@ apt-get -y purge openssh-{client,server} >/dev/null
 apt-get autoremove >/dev/null
 
 msg "Updating container OS..."
+    apt update &>/dev/null
 
 msg "Installing prerequisites..."
 apt-get -qqy install \


### PR DESCRIPTION
Restoring the container "apt update" command due to script "breaking" at "Installing prerequisites...".